### PR TITLE
PES-10025: fix TARGET_OS_SIMULATOR not in scope error

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -125,7 +125,11 @@ public enum PopupConfigure {
 
 public struct Platform {
     public static var isSimulator: Bool {
-        return TARGET_OS_SIMULATOR != 0 // Use this line in Xcode 7 or newer
+        #if targetEnvironment(simulator)
+            return true
+        #else
+            return false
+        #endif
     }
 }
 


### PR DESCRIPTION
Replace TARGET_OS_SIMULATOR with #if targetEnvironment(simulator) 
### Jira
[[TARGET_OS_SIMULATOR](https://myxplorinfo.atlassian.net/browse/PES-10025)](https://myxplorinfo.atlassian.net/browse/PES-10025)